### PR TITLE
Some fixups to match the new environment

### DIFF
--- a/labs/lab1/chapter1.md
+++ b/labs/lab1/chapter1.md
@@ -8,15 +8,11 @@ itself as well as walk through some exercises with a couple of Docker images
 / containers to tell a complete story and point out some things that you might 
 have to consider when containerizing your application.
 
-This lab should be performed on **rhel-cdk.example.com** unless otherwise instructed.
+This lab should be performed on **workstation.example.com** unless otherwise instructed.
 
-The **rhel-cdk.example.com** machine should have been brought up in
-lab0. You can access that machine using the following commands:
-
-```
-cd ~/summit-2017-container-lab/vagrantcdklab
-vagrant ssh
-```
+The **cdk.example.com** running minishift should have been brought up in lab0. 
+You can access that machine using the ```oc``` and ```docker``` commands as shown
+in lab0.
 
 Expected completion: 15-20 minutes
 
@@ -158,7 +154,7 @@ docker build -t redhat/apache .
 Next, let's run the image and make sure it started.
 
 ```bash
-docker run -dt -p 80:80 --name apache redhat/apache
+docker run -dt -p 1080:80 --name apache redhat/apache
 docker ps
 ```
 
@@ -174,7 +170,7 @@ the container. Finally, we passed in the name of the image that we built earlier
 Okay, let's make sure we can access the web server.
 
 ```bash
-curl http://localhost
+curl http://cdk.example.com:1080
 Apache
 ```
 

--- a/labs/lab2/chapter2.md
+++ b/labs/lab2/chapter2.md
@@ -11,7 +11,8 @@ of multiple services. We will also observe several bad practices when
 composing Dockerfiles and explore how to avoid those mistakes. In lab 3
 we will decompose the application into more manageable pieces.
 
-This lab should be performed on **rhel-cdk.example.com** unless otherwise instructed.
+This lab should be performed on **workstation.example.com** unless 
+otherwise instructed.
 
 Expected completion: 20-25 minutes
 
@@ -59,7 +60,7 @@ To run the docker container based on the image we just built use the
 following command:
 
 ```bash
-docker run -p 80 --name=bigapp -e DBUSER=user -e DBPASS=mypassword -e DBNAME=mydb -d bigimg
+docker run -p 1080 --name=bigapp -e DBUSER=user -e DBPASS=mypassword -e DBNAME=mydb -d bigimg
 docker ps
 ```
 
@@ -113,10 +114,10 @@ port 80:
 docker port bigapp 80
 ```
 
-Now connect to the port via the web browser on your machine using ```http://rhel-cdk.example.com:<port>```.  You can also use curl to connect, for example:
+Now connect to the port via the web browser on your machine using ```http://cdk.example.com:<port>```.  You can also use curl to connect, for example:
 
 ```bash
-curl -L http://rhel-cdk.example.com:<port>
+curl -L http://cdk.example.com:<port>
 ```
 
 ## Review Dockerfile practices

--- a/labs/lab3/chapter3.md
+++ b/labs/lab3/chapter3.md
@@ -4,7 +4,7 @@ In this lab you will deconstruct an application into microservices, creating
 a multi-container application. In this process we explore the challenges of 
 networking, storage and configuration.
 
-This lab should be performed on **rhel-cdk.example.com** unless otherwise instructed.
+This lab should be performed on **workstation.example.com** unless otherwise instructed.
 
 Expected completion: 20-30 minutes
 
@@ -199,7 +199,7 @@ Now we are ready to build the images to test our Dockerfiles.
 
         docker images
 
-1. Configure the local directories for persistent storage. We also need to change 
+1. XXXXX local dirs don't work. skip this section. see [#24](https://github.com/dustymabe/summit-2017-container-lab/issues/24) Configure the local directories for persistent storage. We also need to change 
    the SELinux context so the applications have permission to read and write to the 
    directories.
 
@@ -219,10 +219,11 @@ Now we are ready to build the images to test our Dockerfiles.
   * `-v <host/path>:<container/path>` to bindmount the directory for persistent storage
   * `-p <host_port>:<container_port>` to map the container port to the host port
 
-            docker run -d -v /var/lib/mariadb:/var/lib/mysql -p 3306:3306 -e DBUSER=user -e DBPASS=mypassword -e DBNAME=mydb --name mariadb mariadb
+            DONT RUN THIS ONE FOR NOW docker run -d -v /var/lib/mariadb:/var/lib/mysql -p 3306:3306 -e DBUSER=user -e DBPASS=mypassword -e DBNAME=mydb --name mariadb mariadb
+            docker run -d -p 3306:3306 -e DBUSER=user -e DBPASS=mypassword -e DBNAME=mydb --name mariadb mariadb
             docker logs $(docker ps -ql)
-            sudo ls -l /var/lib/mariadb
-            curl http://localhost:3306
+            DONT RUN THIS ONE FOR NOW sudo ls -l /var/lib/mariadb
+            curl http://cdk.example.com:3306
 
   **Note**: the `curl` command does not return useful information but demonstrates 
             a response on the port.
@@ -230,11 +231,12 @@ Now we are ready to build the images to test our Dockerfiles.
 1. Test the Wordpress image to confirm connectivity. Additional run options:
   * `--link <name>:<alias>` to link to the database container
 
-            docker run -d -v /var/lib/wp_uploads:/var/www/html/wp-content/ -p 80:80 --link mariadb:db --name wordpress wordpress
+            DONT RUN THIS ONE FOR NOW docker run -d -v /var/lib/wp_uploads:/var/www/html/wp-content/ -p 80:80 --link mariadb:db --name wordpress wordpress
+            docker run -d -p 1080:80 --link mariadb:db --name wordpress wordpress
             docker logs $(docker ps -ql)
-            sudo ls -l /var/lib/wp_uploads
+            DONT RUN THIS ONE FOR NOW sudo ls -l /var/lib/wp_uploads
             docker ps
-            curl -L http://localhost
+            curl -L http://cdk.example.com:1080
 
 You may also load the Wordpress application in a browser to test its full functionality.
 
@@ -252,7 +254,8 @@ to copy+paste from README files.
 1. Edit `wordpress/Dockerfile` and add the following instruction near the bottom 
    of the file above the CMD line.
 
-        LABEL RUN docker run -d -v /var/lib/wp_uploads:/var/www/html/wp-content/ -p 80:80 --link=mariadb:db --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
+        NOT THIS ONE FOR NOW LABEL RUN docker run -d -v /var/lib/wp_uploads:/var/www/html/wp-content/ -p 80:80 --link=mariadb:db --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
+        LABEL RUN docker run -d -p 1080:80 --link=mariadb:db --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE
 
 1. Rebuild the Wordpress image. The image cache will be used so only the changes 
    will need to be built.
@@ -264,21 +267,21 @@ to copy+paste from README files.
 
         docker stop wordpress
         docker rm wordpress
-        sudo atomic run wordpress
-        curl -L http://localhost
+        atomic run wordpress
+        curl -L http://cdk.example.com:1080
 
 1. Once satisfied with the images tag them with the URI of the local lab local registry. 
    The tag is what Docker uses to identify the particular image that we want to upload to
    a registry.
 
-        docker tag mariadb rhel-cdk.example.com:5000/mariadb
-        docker tag wordpress rhel-cdk.example.com:5000/wordpress
+        docker tag mariadb cdk.example.com:5000/mariadb
+        docker tag wordpress cdk.example.com:5000/wordpress
         docker images
 
 1. Push the images
 
-        docker push rhel-cdk.example.com:5000/mariadb
-        docker push rhel-cdk.example.com:5000/wordpress
+        docker push cdk.example.com:5000/mariadb
+        docker push cdk.example.com:5000/wordpress
 
 ## Clean Up
 
@@ -302,5 +305,6 @@ This command is useful in freeing up disk space by removing all stopped containe
 docker rm $(docker ps -qa)
 ```
 
-This command will result in a cosmetic error because it is trying to stop a running 
-container - the registry.  This can safely be ignored.
+This command will result in a cosmetic error because it is trying to stop running 
+containers like the registry and the OpenShift containers that are running. These
+errors can safely be ignored.

--- a/labs/lab4/chapter4.md
+++ b/labs/lab4/chapter4.md
@@ -3,7 +3,7 @@
 In this lab we introduce how to orchestrate a multi-container application in 
 OpenShift.
 
-This lab should be performed on **rhel-cdk.example.com** unless otherwise instructed.
+This lab should be performed on **workstation.example.com** unless otherwise instructed.
 
 Expected completion: 40-60 minutes
 
@@ -15,11 +15,11 @@ So, let's see what will happen. Launch the site:
 
 ```bash
 docker run -d -p 3306:3306 -e DBUSER=user -e DBPASS=mypassword -e DBNAME=mydb --name mariadb mariadb
-docker run -d -p 80:80 --link mariadb:db --name wordpress wordpress
+docker run -d -p 1080:80 --link mariadb:db --name wordpress wordpress
 ```
 
 Take a look at the site in your web browser on your machine using 
-[http://rhel-cdk.example.com](http://rhel-cdk.example.com). As you learned 
+[http://cdk.example.com](http://cdk.example.com). As you learned 
 before, you can confirm the port that your server is running on by
 executing:
 
@@ -37,7 +37,7 @@ ip addr show dev eth1
 ```
 
 However, we have some nice DNS set up and chose port 80, so you 
-can just use [http://rhel-cdk.example.com](http://rhel-cdk.example.com).
+can just use [http://cdk.example.com](http://cdk.example.com).
 
 Now, let's see what happens when we kick over the database. However,
 for a later experiment, let's grab the container-id right before you do it. 
@@ -52,7 +52,7 @@ imagine, explosions! (*making sound effects will be much appreciated
 by your lab mates.*)
 
 ```bash
-web browser -> http://rhel-cdk.example.com OR curl -L http://rhel-cdk.example.com
+web browser -> http://cdk.example.com OR curl -L http://cdk.example.com
 ```
 
 Now, what is neat about a container system, assuming your web application
@@ -74,7 +74,7 @@ about what you would expect for a web server and a database running on
 VMs, but a whole lot faster. Let's take a look at the site now.
 
 ```bash
-web browser -> http://rhel-cdk.example.com OR curl -L http://rhel-cdk.example.com
+web browser -> http://cdk.example.com OR curl -L http://cdk.example.com
 ```
 
 And.. Your site is back! Fortunately wordpress seems to be designed
@@ -92,7 +92,9 @@ Starting and stopping is definitely easy, and fast. However, it is still pretty 
 What if we could automate the recovery? Or, in buzzword terms, "ensure the service 
 remains available"? Enter Kubernetes/OpenShift.
 
-## Starting OpenShift on the CDK
+## XXX maybe this should be a "starting Atomic Host section" Starting OpenShift on the CDK
+
+ignore this section for now, just ```oc new-project devel```. 
 
 The Vagrantfile we used to bring up the CDK in lab1 does not start
 OpenShift by default. We chose to do this so that we could play around
@@ -171,7 +173,7 @@ To start, we will add the most basic information. Please replace the
 ```
   containers:
     - name: mariadb
-      image: rhel-cdk.example.com:5000/mariadb
+      image: cdk.example.com:5000/mariadb
       ports:
         - containerPort: 3306
       env:
@@ -206,7 +208,7 @@ metadata:
 spec:
   containers:
     - name: mariadb
-      image: rhel-cdk.example.com:5000/mariadb
+      image: cdk.example.com:5000/mariadb
       ports:
         - containerPort: 3306
       env:
@@ -235,7 +237,7 @@ metadata:
 spec:
   containers:
   - name: wordpress
-    image: rhel-cdk.example.com:5000/wordpress
+    image: cdk.example.com:5000/wordpress
     ports:
       - containerPort: 80
     env:
@@ -416,13 +418,13 @@ And you should be able to see the service's accessible URL by viewing the routes
 ```bash
 $ oc get routes
 NAME        HOST/PORT                                           PATH      SERVICE     LABELS           INSECURE POLICY   TLS TERMINATION
-wordpress   wordpress-sample-project.rhel-cdk.10.1.2.2.xip.io             wordpress   name=wordpress
+wordpress   wordpress-devel.cdk.example.com                     wordpress   name=wordpress
 ```
 
 Check and make sure you can access the wordpress service through the route:
 
 ```bash
-curl -L http://wordpress-sample-project.rhel-cdk.10.1.2.2.xip.io
+curl -L wordpress-devel.cdk.example.com
 or
 point your browser to the URL to view the GUI
 ```
@@ -440,7 +442,7 @@ First, let's log in to the remote cluster:
 
 ```bash
 oc login --insecure-skip-tls-verify=true \
-    -u openshift-dev -p devel https://deploy.example.com:8443
+    -u developer -p developer atomic-host.example.com:8443
 ```
 
 This will create a new configuration file in ~/.kube/config. This
@@ -487,13 +489,13 @@ oc expose svc/wordpress
 ```bash
 $ oc get routes
 NAME        HOST/PORT                                                 PATH      SERVICE     LABELS           INSECURE POLICY   TLS TERMINATION
-wordpress   wordpress-production.deploy.example.com.10.1.2.3.xip.io             wordpress   name=wordpress 
+wordpress   wordpress-production.atomic-host.example.com            wordpress   name=wordpress 
 ```
 
 And finally, access the site via the link:
 
 ```
-curl -L http://wordpress-production.deploy.example.com.10.1.2.3.xip.io
+curl -L http://wordpress-production.atomic-host.example.com
 or
 point your browser to the URL
 ```

--- a/labs/lab4/mariadb/openshift/mariadb-pod.yaml
+++ b/labs/lab4/mariadb/openshift/mariadb-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: mariadb
-      image: rhel-cdk.example.com:5000/mariadb
+      image: cdk.example.com:5000/mariadb
       ports:
         - containerPort: 3306
       env:

--- a/labs/lab4/wordpress/openshift/wordpress-pod.yaml
+++ b/labs/lab4/wordpress/openshift/wordpress-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: wordpress
-    image: rhel-cdk.example.com:5000/wordpress
+    image: cdk.example.com:5000/wordpress
     ports:
       - containerPort: 80
     env:


### PR DESCRIPTION
rhel-cdk is now just cdk.example.com
moved port 80 on wordpress container to 1080
some wording fixups for new use of cdk
added warnings about volume mounts #24